### PR TITLE
HACK - read server address from config file

### DIFF
--- a/api.go
+++ b/api.go
@@ -88,7 +88,13 @@ func (a *api) runImpl(input common.PluginInput) (err error) {
 		a.cfg.DBFilename = filepath.Join(pluginDir, a.cfg.DBFilename)
 	}
 
-	a.client = util.NewClient(input.ServerConnection)
+	// HACK - get the server address from the server config file
+	serverCfg, err := readServerConfig(filepath.Join(input.ServerConnection.Dir, "config.yml"))
+	if err != nil {
+		return fmt.Errorf("error reading server configuration file: %s", err.Error())
+	}
+
+	a.client = util.NewClient(input.ServerConnection, serverCfg.Host)
 	a.cache = newSceneCache(a.client)
 
 	if cfg.AddTagName != "" {

--- a/config.go
+++ b/config.go
@@ -44,3 +44,25 @@ func readConfig(fn string) (*config, error) {
 
 	return ret, nil
 }
+
+// HACK - read the host from the server config - this should be provided
+// by the server itself
+type serverConfig struct {
+	Host string `yaml:"host"`
+}
+
+func readServerConfig(fn string) (*serverConfig, error) {
+	ret := &serverConfig{}
+
+	file, err := os.Open(fn)
+	defer file.Close()
+	if err != nil {
+		return nil, err
+	}
+	parser := yaml.NewDecoder(file)
+	if err := parser.Decode(&ret); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}

--- a/internal/plugin/util/client.go
+++ b/internal/plugin/util/client.go
@@ -3,10 +3,10 @@
 package util
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
-	"strconv"
 
 	"github.com/shurcooL/graphql"
 
@@ -15,11 +15,8 @@ import (
 
 // NewClient creates a graphql Client connecting to the stash server using
 // the provided server connection details.
-// Always connects to the graphql endpoint of the localhost.
-func NewClient(provider common.StashServerConnection) *graphql.Client {
-	portStr := strconv.Itoa(provider.Port)
-
-	u, _ := url.Parse("http://localhost:" + portStr + "/graphql")
+func NewClient(provider common.StashServerConnection, addr string) *graphql.Client {
+	u, _ := url.Parse(fmt.Sprintf("http://%s:%d/graphql", addr, provider.Port))
 	u.Scheme = provider.Scheme
 
 	cookieJar, _ := cookiejar.New(nil)


### PR DESCRIPTION
Resolves #4

Reads the correct host address from the stash config file. This is a temporary hack until this information is provided by the stash server.